### PR TITLE
Add backwards compatibility for Pipecat tracing API changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pipecat-ai[cartesia,daily,deepgram,silero]>=0.0.98",
     "aiortc>=1.14.0",
     "apscheduler>=3.10.0",
+    "packaging>=21.0",
 ]
 
 [project.scripts]

--- a/src/finchvox/__init__.py
+++ b/src/finchvox/__init__.py
@@ -1,6 +1,7 @@
 import logging
 from importlib.metadata import version
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
 from loguru import logger
 from opentelemetry import trace as otel_trace
@@ -8,9 +9,22 @@ from opentelemetry.sdk.trace import TracerProvider
 
 from finchvox.environment import EnvironmentSpanProcessor, capture_environment
 
+if TYPE_CHECKING:
+    from pipecat.utils.tracing.tracing_context import TracingContext
+
 _initialized = False
 _allowed_log_modules: set[str] = {"pipecat.", "finchvox.", "__main__"}
 _app_root: Path | None = None
+_current_tracing_context: Optional["TracingContext"] = None
+
+
+def set_tracing_context(ctx: "TracingContext") -> None:
+    global _current_tracing_context
+    _current_tracing_context = ctx
+
+
+def get_tracing_context() -> Optional["TracingContext"]:
+    return _current_tracing_context
 
 
 def init(
@@ -75,30 +89,33 @@ def init(
     )
 
 
-def _is_allowed_source(module: str, pathname: str | None) -> bool:
-    """Check if a log source should be captured.
-
-    A source is allowed if:
-    1. The module name matches an allowed prefix (pipecat., finchvox., __main__), OR
-    2. The file path is within the app_root directory (excluding site-packages, .venv)
-    """
+def _matches_allowed_module(module: str) -> bool:
     for prefix in _allowed_log_modules:
-        if prefix == "__main__":
-            if module == "__main__":
-                return True
-        elif module.startswith(prefix):
+        if prefix == "__main__" and module == "__main__":
             return True
+        if prefix != "__main__" and module.startswith(prefix):
+            return True
+    return False
 
-    if pathname and _app_root:
-        try:
-            path = Path(pathname).resolve()
-            if path.is_relative_to(_app_root):
-                path_str = str(path)
-                if "site-packages" not in path_str and "/.venv/" not in path_str:
-                    return True
-        except (ValueError, OSError):
-            pass
 
+def _is_path_in_app_root(pathname: str) -> bool:
+    if not _app_root:
+        return False
+    try:
+        path = Path(pathname).resolve()
+        if not path.is_relative_to(_app_root):
+            return False
+        path_str = str(path)
+        return "site-packages" not in path_str and "/.venv/" not in path_str
+    except (ValueError, OSError):
+        return False
+
+
+def _is_allowed_source(module: str, pathname: str | None) -> bool:
+    if _matches_allowed_module(module):
+        return True
+    if pathname and _is_path_in_app_root(pathname):
+        return True
     return False
 
 
@@ -164,15 +181,7 @@ def _setup_log_capture(service_name: str, endpoint: str, insecure: bool) -> None
     logger.debug("OpenTelemetry log capture initialized")
 
 
-def _get_pipecat_context():
-    """Get current trace context from Pipecat's turn or conversation provider.
-
-    OpenTelemetry's LoggingInstrumentor reads trace context from thread-local
-    contextvars, but Pipecat stores the current turn's span context in a custom
-    singleton (TurnContextProvider). This function bridges the gap by retrieving
-    the context from Pipecat's providers so we can inject it into thread-local
-    storage before forwarding logs.
-    """
+def _get_legacy_pipecat_context():
     try:
         from pipecat.utils.tracing.turn_context_provider import get_current_turn_context
 
@@ -186,6 +195,18 @@ def _get_pipecat_context():
         return get_current_conversation_context()
     except ImportError:
         return None
+
+
+def _get_pipecat_context():
+    """Get current trace context from Pipecat's turn or conversation provider."""
+    from finchvox.compat import HAS_NEW_TRACING_API
+
+    if HAS_NEW_TRACING_API:
+        ctx = get_tracing_context()
+        if ctx:
+            return ctx.get_turn_context() or ctx.get_conversation_context()
+        return None
+    return _get_legacy_pipecat_context()
 
 
 def _setup_loguru_bridge() -> None:

--- a/src/finchvox/compat.py
+++ b/src/finchvox/compat.py
@@ -1,0 +1,27 @@
+from importlib.metadata import version
+
+from packaging.version import Version
+
+PIPECAT_NEW_TRACING_VERSION = Version("0.0.103")
+
+
+def _get_pipecat_version() -> Version:
+    try:
+        return Version(version("pipecat-ai"))
+    except Exception:
+        return Version("0.0.0")
+
+
+def has_new_tracing_api() -> bool:
+    pipecat_version = _get_pipecat_version()
+    if pipecat_version >= PIPECAT_NEW_TRACING_VERSION:
+        return True
+    try:
+        from pipecat.utils.tracing.tracing_context import TracingContext  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+HAS_NEW_TRACING_API = has_new_tracing_api()

--- a/src/finchvox/processor.py
+++ b/src/finchvox/processor.py
@@ -3,7 +3,7 @@ import io
 import json
 import wave
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import aiohttp
 from loguru import logger
@@ -22,9 +22,16 @@ from pipecat.processors.frame_processor import (
     FrameProcessor,
     FrameProcessorSetup,
 )
-from pipecat.utils.tracing.conversation_context_provider import (
-    ConversationContextProvider,
-)
+
+from finchvox.compat import HAS_NEW_TRACING_API
+
+if TYPE_CHECKING:
+    from pipecat.utils.tracing.tracing_context import TracingContext
+
+if not HAS_NEW_TRACING_API:
+    from pipecat.utils.tracing.conversation_context_provider import (
+        ConversationContextProvider,
+    )
 
 
 def _is_finchvox_initialized() -> bool:
@@ -85,6 +92,7 @@ class FinchvoxProcessor(FrameProcessor):
         self._chunk_counter = 0
         self._setup_info: Optional[FrameProcessorSetup] = None
         self._input_frame_count = 0
+        self._tracing_context: Optional["TracingContext"] = None
 
     async def setup(self, setup: FrameProcessorSetup):
         await super().setup(setup)
@@ -143,6 +151,13 @@ class FinchvoxProcessor(FrameProcessor):
             )
             self._disabled = True
             return
+
+        if HAS_NEW_TRACING_API:
+            self._tracing_context = getattr(frame, "tracing_context", None)
+            if self._tracing_context:
+                import finchvox
+
+                finchvox.set_tracing_context(self._tracing_context)
 
         self._audio_buffer = AudioBufferProcessor(
             sample_rate=self._sample_rate,
@@ -212,19 +227,31 @@ class FinchvoxProcessor(FrameProcessor):
             except Exception as e:
                 logger.error(f"Failed to process audio chunk: {e}", exc_info=True)
 
+    def _extract_trace_id_from_context(self, ctx) -> Optional[str]:
+        if not ctx:
+            return None
+        span = trace.get_current_span(ctx)
+        span_context = span.get_span_context()
+        if span_context.trace_id == 0:
+            return None
+        return format(span_context.trace_id, "032x")
+
     def _get_trace_id(self) -> str:
         try:
-            context_provider = ConversationContextProvider.get_instance()
-            conversation_context = context_provider.get_current_conversation_context()
-
-            if conversation_context:
-                span = trace.get_current_span(conversation_context)
-                span_context = span.get_span_context()
-                if span_context.trace_id != 0:
-                    return format(span_context.trace_id, "032x")
+            if HAS_NEW_TRACING_API:
+                ctx = (
+                    self._tracing_context.get_conversation_context()
+                    if self._tracing_context
+                    else None
+                )
+            else:
+                provider = ConversationContextProvider.get_instance()
+                ctx = provider.get_current_conversation_context()
+            trace_id = self._extract_trace_id_from_context(ctx)
+            if trace_id:
+                return trace_id
         except Exception:
             pass
-
         return "no_trace"
 
     async def _upload_chunk(

--- a/uv.lock
+++ b/uv.lock
@@ -925,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "finchvox"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -939,6 +939,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-proto" },
     { name = "opentelemetry-sdk" },
+    { name = "packaging" },
     { name = "pipecat-ai", extra = ["cartesia", "daily", "deepgram", "silero"] },
     { name = "protobuf" },
     { name = "python-multipart" },
@@ -968,6 +969,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.48b0" },
     { name = "opentelemetry-proto", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
+    { name = "packaging", specifier = ">=21.0" },
     { name = "pipecat-ai", extras = ["cartesia", "daily", "deepgram", "silero"], specifier = ">=0.0.98" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "protobuf", specifier = ">=4.25.0" },


### PR DESCRIPTION
## Summary

- Adds compatibility layer for Pipecat's refactored tracing module (>= 0.0.103)
- Supports both old singleton-based API and new per-pipeline TracingContext API
- Fixes `ModuleNotFoundError: No module named 'pipecat.utils.tracing.conversation_context_provider'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)