### PR TITLE
Add pagination to sessions list

### DIFF
--- a/src/finchvox/session_repository.py
+++ b/src/finchvox/session_repository.py
@@ -1,0 +1,84 @@
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+from finchvox.session import Session
+
+DEFAULT_PAGE_SIZE = 50
+
+
+@dataclass
+class PaginatedSessions:
+    sessions: list[dict]
+    total_count: int
+    total_pages: int
+    page: int
+    page_size: int
+    has_previous_page: bool
+    has_next_page: bool
+    data_dir: str
+
+    def to_dict(self) -> dict:
+        return {
+            "sessions": self.sessions,
+            "total_count": self.total_count,
+            "total_pages": self.total_pages,
+            "page": self.page,
+            "page_size": self.page_size,
+            "has_previous_page": self.has_previous_page,
+            "has_next_page": self.has_next_page,
+            "data_dir": self.data_dir,
+        }
+
+
+class SessionRepository:
+    def __init__(self, sessions_base_dir: Path, page_size: int = DEFAULT_PAGE_SIZE):
+        self.sessions_base_dir = sessions_base_dir
+        self.page_size = page_size
+
+    def _load_all_sessions(self) -> list[dict]:
+        if not self.sessions_base_dir.exists():
+            return []
+
+        sessions = []
+        for session_dir in self.sessions_base_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+
+            session_id = session_dir.name
+            trace_file = session_dir / f"trace_{session_id}.jsonl"
+
+            if not trace_file.exists():
+                continue
+
+            try:
+                session = Session(session_dir)
+                sessions.append(session.to_dict())
+            except Exception as e:
+                print(f"Error reading session {session_dir}: {e}")
+                continue
+
+        sessions.sort(key=lambda s: s.get("start_time") or 0, reverse=True)
+        return sessions
+
+    def list_paginated(self, page: int = 1) -> PaginatedSessions:
+        all_sessions = self._load_all_sessions()
+        total_count = len(all_sessions)
+        total_pages = max(1, math.ceil(total_count / self.page_size))
+
+        page = max(1, min(page, total_pages))
+
+        start_index = (page - 1) * self.page_size
+        end_index = start_index + self.page_size
+        page_sessions = all_sessions[start_index:end_index]
+
+        return PaginatedSessions(
+            sessions=page_sessions,
+            total_count=total_count,
+            total_pages=total_pages,
+            page=page,
+            page_size=self.page_size,
+            has_previous_page=page > 1,
+            has_next_page=page < total_pages,
+            data_dir=str(self.sessions_base_dir),
+        )

--- a/src/finchvox/ui_routes.py
+++ b/src/finchvox/ui_routes.py
@@ -11,6 +11,7 @@ from finchvox.audio_utils import find_chunks, combine_chunks
 from finchvox.conversation import Conversation
 from finchvox.metrics import Metrics
 from finchvox.session import Session
+from finchvox.session_repository import SessionRepository
 from finchvox.collector.config import (
     get_sessions_base_dir,
     get_session_dir,
@@ -71,30 +72,10 @@ def _get_combined_audio_file(
     return tmp_path, "audio/wav", True
 
 
-async def _handle_list_sessions(sessions_base_dir: Path) -> JSONResponse:
-    if not sessions_base_dir.exists():
-        return JSONResponse({"sessions": [], "data_dir": str(sessions_base_dir)})
-
-    sessions = []
-    for session_dir in sessions_base_dir.iterdir():
-        if not session_dir.is_dir():
-            continue
-
-        session_id = session_dir.name
-        trace_file = session_dir / f"trace_{session_id}.jsonl"
-
-        if not trace_file.exists():
-            continue
-
-        try:
-            session = Session(session_dir)
-            sessions.append(session.to_dict())
-        except Exception as e:
-            print(f"Error reading session {session_dir}: {e}")
-            continue
-
-    sessions.sort(key=lambda s: s.get("start_time") or 0, reverse=True)
-    return JSONResponse({"sessions": sessions, "data_dir": str(sessions_base_dir)})
+async def _handle_list_sessions(sessions_base_dir: Path, page: int = 1) -> JSONResponse:
+    repository = SessionRepository(sessions_base_dir)
+    result = repository.list_paginated(page)
+    return JSONResponse(result.to_dict())
 
 
 def _get_session(data_dir: Path, session_id: str) -> Session:
@@ -310,8 +291,8 @@ def register_ui_routes(app: FastAPI, data_dir: Path = None):
         return FileResponse(str(UI_DIR / "session_detail.html"))
 
     @app.get("/api/sessions")
-    async def list_sessions() -> JSONResponse:
-        return await _handle_list_sessions(sessions_base_dir)
+    async def list_sessions(page: int = 1) -> JSONResponse:
+        return await _handle_list_sessions(sessions_base_dir, page)
 
     @app.get("/api/sessions/{session_id}/trace")
     async def get_session_trace(session_id: str) -> JSONResponse:

--- a/tests/test_session_repository.py
+++ b/tests/test_session_repository.py
@@ -1,0 +1,162 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from finchvox.session_repository import SessionRepository, DEFAULT_PAGE_SIZE
+
+
+@pytest.fixture
+def temp_sessions_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "sessions"
+
+
+def create_session(sessions_dir: Path, session_id: str, start_time_nano: int):
+    session_dir = sessions_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    trace_file = session_dir / f"trace_{session_id}.jsonl"
+    span = {
+        "name": "test-span",
+        "start_time_unix_nano": start_time_nano,
+        "end_time_unix_nano": start_time_nano + 1000000000,
+    }
+    with trace_file.open("w") as f:
+        json.dump(span, f)
+        f.write("\n")
+
+
+class TestSessionRepository:
+    def test_empty_directory_returns_empty_result(self, temp_sessions_dir):
+        repo = SessionRepository(temp_sessions_dir)
+        result = repo.list_paginated()
+
+        assert result.sessions == []
+        assert result.total_count == 0
+        assert result.total_pages == 1
+        assert result.page == 1
+        assert result.has_previous_page is False
+        assert result.has_next_page is False
+
+    def test_nonexistent_directory_returns_empty_result(self, temp_sessions_dir):
+        repo = SessionRepository(temp_sessions_dir / "nonexistent")
+        result = repo.list_paginated()
+
+        assert result.sessions == []
+        assert result.total_count == 0
+
+    def test_sessions_sorted_by_start_time_descending(self, temp_sessions_dir):
+        create_session(temp_sessions_dir, "session1", 1000000000000000000)
+        create_session(temp_sessions_dir, "session2", 3000000000000000000)
+        create_session(temp_sessions_dir, "session3", 2000000000000000000)
+
+        repo = SessionRepository(temp_sessions_dir)
+        result = repo.list_paginated()
+
+        assert len(result.sessions) == 3
+        assert result.sessions[0]["session_id"] == "session2"
+        assert result.sessions[1]["session_id"] == "session3"
+        assert result.sessions[2]["session_id"] == "session1"
+
+    def test_first_page_returns_correct_sessions(self, temp_sessions_dir):
+        for i in range(75):
+            create_session(
+                temp_sessions_dir, f"session{i:03d}", i * 1000000000000000000
+            )
+
+        repo = SessionRepository(temp_sessions_dir, page_size=50)
+        result = repo.list_paginated(page=1)
+
+        assert len(result.sessions) == 50
+        assert result.total_count == 75
+        assert result.total_pages == 2
+        assert result.page == 1
+        assert result.page_size == 50
+        assert result.has_previous_page is False
+        assert result.has_next_page is True
+
+    def test_second_page_returns_remaining_sessions(self, temp_sessions_dir):
+        for i in range(75):
+            create_session(
+                temp_sessions_dir, f"session{i:03d}", i * 1000000000000000000
+            )
+
+        repo = SessionRepository(temp_sessions_dir, page_size=50)
+        result = repo.list_paginated(page=2)
+
+        assert len(result.sessions) == 25
+        assert result.total_count == 75
+        assert result.total_pages == 2
+        assert result.page == 2
+        assert result.has_previous_page is True
+        assert result.has_next_page is False
+
+    def test_invalid_page_zero_clamped_to_one(self, temp_sessions_dir):
+        create_session(temp_sessions_dir, "session1", 1000000000000000000)
+
+        repo = SessionRepository(temp_sessions_dir)
+        result = repo.list_paginated(page=0)
+
+        assert result.page == 1
+
+    def test_invalid_page_negative_clamped_to_one(self, temp_sessions_dir):
+        create_session(temp_sessions_dir, "session1", 1000000000000000000)
+
+        repo = SessionRepository(temp_sessions_dir)
+        result = repo.list_paginated(page=-5)
+
+        assert result.page == 1
+
+    def test_invalid_page_too_high_clamped_to_max(self, temp_sessions_dir):
+        for i in range(10):
+            create_session(temp_sessions_dir, f"session{i}", i * 1000000000000000000)
+
+        repo = SessionRepository(temp_sessions_dir, page_size=5)
+        result = repo.list_paginated(page=100)
+
+        assert result.page == 2
+        assert result.total_pages == 2
+
+    def test_total_pages_calculation(self, temp_sessions_dir):
+        for i in range(101):
+            create_session(
+                temp_sessions_dir, f"session{i:03d}", i * 1000000000000000000
+            )
+
+        repo = SessionRepository(temp_sessions_dir, page_size=50)
+        result = repo.list_paginated()
+
+        assert result.total_pages == 3
+        assert result.total_count == 101
+
+    def test_single_session_returns_one_page(self, temp_sessions_dir):
+        create_session(temp_sessions_dir, "session1", 1000000000000000000)
+
+        repo = SessionRepository(temp_sessions_dir)
+        result = repo.list_paginated()
+
+        assert result.total_pages == 1
+        assert result.total_count == 1
+        assert result.has_previous_page is False
+        assert result.has_next_page is False
+
+    def test_to_dict_returns_all_fields(self, temp_sessions_dir):
+        create_session(temp_sessions_dir, "session1", 1000000000000000000)
+
+        repo = SessionRepository(temp_sessions_dir)
+        result = repo.list_paginated()
+        d = result.to_dict()
+
+        assert "sessions" in d
+        assert "total_count" in d
+        assert "total_pages" in d
+        assert "page" in d
+        assert "page_size" in d
+        assert "has_previous_page" in d
+        assert "has_next_page" in d
+        assert "data_dir" in d
+
+    def test_default_page_size_is_50(self):
+        assert DEFAULT_PAGE_SIZE == 50

--- a/tests/test_session_repository.py
+++ b/tests/test_session_repository.py
@@ -13,6 +13,12 @@ def temp_sessions_dir():
         yield Path(tmpdir) / "sessions"
 
 
+@pytest.fixture
+def single_session_dir(temp_sessions_dir):
+    create_session(temp_sessions_dir, "session1", 1000000000000000000)
+    return temp_sessions_dir
+
+
 def create_session(sessions_dir: Path, session_id: str, start_time_nano: int):
     session_dir = sessions_dir / session_id
     session_dir.mkdir(parents=True, exist_ok=True)
@@ -92,19 +98,10 @@ class TestSessionRepository:
         assert result.has_previous_page is True
         assert result.has_next_page is False
 
-    def test_invalid_page_zero_clamped_to_one(self, temp_sessions_dir):
-        create_session(temp_sessions_dir, "session1", 1000000000000000000)
-
-        repo = SessionRepository(temp_sessions_dir)
-        result = repo.list_paginated(page=0)
-
-        assert result.page == 1
-
-    def test_invalid_page_negative_clamped_to_one(self, temp_sessions_dir):
-        create_session(temp_sessions_dir, "session1", 1000000000000000000)
-
-        repo = SessionRepository(temp_sessions_dir)
-        result = repo.list_paginated(page=-5)
+    @pytest.mark.parametrize("invalid_page", [0, -1, -5])
+    def test_invalid_page_clamped_to_one(self, single_session_dir, invalid_page):
+        repo = SessionRepository(single_session_dir)
+        result = repo.list_paginated(page=invalid_page)
 
         assert result.page == 1
 
@@ -126,10 +123,8 @@ class TestSessionRepository:
         assert result.total_pages == 3
         assert result.total_count == 101
 
-    def test_single_session_returns_one_page(self, temp_sessions_dir):
-        create_session(temp_sessions_dir, "session1", 1000000000000000000)
-
-        repo = SessionRepository(temp_sessions_dir)
+    def test_single_session_returns_one_page(self, single_session_dir):
+        repo = SessionRepository(single_session_dir)
         result = repo.list_paginated()
 
         assert result.total_pages == 1
@@ -137,10 +132,8 @@ class TestSessionRepository:
         assert result.has_previous_page is False
         assert result.has_next_page is False
 
-    def test_to_dict_returns_all_fields(self, temp_sessions_dir):
-        create_session(temp_sessions_dir, "session1", 1000000000000000000)
-
-        repo = SessionRepository(temp_sessions_dir)
+    def test_to_dict_returns_all_fields(self, single_session_dir):
+        repo = SessionRepository(single_session_dir)
         result = repo.list_paginated()
         d = result.to_dict()
 

--- a/tests/test_session_repository.py
+++ b/tests/test_session_repository.py
@@ -28,6 +28,11 @@ def create_session(sessions_dir: Path, session_id: str, start_time_nano: int):
         f.write("\n")
 
 
+def create_sessions(sessions_dir: Path, count: int):
+    for i in range(count):
+        create_session(sessions_dir, f"session{i:03d}", i * 1000000000000000000)
+
+
 class TestSessionRepository:
     def test_empty_directory_returns_empty_result(self, temp_sessions_dir):
         repo = SessionRepository(temp_sessions_dir)
@@ -61,10 +66,7 @@ class TestSessionRepository:
         assert result.sessions[2]["session_id"] == "session1"
 
     def test_first_page_returns_correct_sessions(self, temp_sessions_dir):
-        for i in range(75):
-            create_session(
-                temp_sessions_dir, f"session{i:03d}", i * 1000000000000000000
-            )
+        create_sessions(temp_sessions_dir, 75)
 
         repo = SessionRepository(temp_sessions_dir, page_size=50)
         result = repo.list_paginated(page=1)
@@ -78,10 +80,7 @@ class TestSessionRepository:
         assert result.has_next_page is True
 
     def test_second_page_returns_remaining_sessions(self, temp_sessions_dir):
-        for i in range(75):
-            create_session(
-                temp_sessions_dir, f"session{i:03d}", i * 1000000000000000000
-            )
+        create_sessions(temp_sessions_dir, 75)
 
         repo = SessionRepository(temp_sessions_dir, page_size=50)
         result = repo.list_paginated(page=2)
@@ -110,8 +109,7 @@ class TestSessionRepository:
         assert result.page == 1
 
     def test_invalid_page_too_high_clamped_to_max(self, temp_sessions_dir):
-        for i in range(10):
-            create_session(temp_sessions_dir, f"session{i}", i * 1000000000000000000)
+        create_sessions(temp_sessions_dir, 10)
 
         repo = SessionRepository(temp_sessions_dir, page_size=5)
         result = repo.list_paginated(page=100)
@@ -120,10 +118,7 @@ class TestSessionRepository:
         assert result.total_pages == 2
 
     def test_total_pages_calculation(self, temp_sessions_dir):
-        for i in range(101):
-            create_session(
-                temp_sessions_dir, f"session{i:03d}", i * 1000000000000000000
-            )
+        create_sessions(temp_sessions_dir, 101)
 
         repo = SessionRepository(temp_sessions_dir, page_size=50)
         result = repo.list_paginated()

--- a/tests/test_session_repository.py
+++ b/tests/test_session_repository.py
@@ -41,19 +41,16 @@ def create_sessions(sessions_dir: Path, count: int):
 
 class TestSessionRepository:
     def test_empty_directory_returns_empty_result(self, temp_sessions_dir):
-        repo = SessionRepository(temp_sessions_dir)
-        result = repo.list_paginated()
+        result = SessionRepository(temp_sessions_dir).list_paginated()
 
         assert result.sessions == []
         assert result.total_count == 0
         assert result.total_pages == 1
-        assert result.page == 1
         assert result.has_previous_page is False
         assert result.has_next_page is False
 
     def test_nonexistent_directory_returns_empty_result(self, temp_sessions_dir):
-        repo = SessionRepository(temp_sessions_dir / "nonexistent")
-        result = repo.list_paginated()
+        result = SessionRepository(temp_sessions_dir / "nonexistent").list_paginated()
 
         assert result.sessions == []
         assert result.total_count == 0
@@ -63,53 +60,47 @@ class TestSessionRepository:
         create_session(temp_sessions_dir, "session2", 3000000000000000000)
         create_session(temp_sessions_dir, "session3", 2000000000000000000)
 
-        repo = SessionRepository(temp_sessions_dir)
-        result = repo.list_paginated()
+        result = SessionRepository(temp_sessions_dir).list_paginated()
 
         assert len(result.sessions) == 3
         assert result.sessions[0]["session_id"] == "session2"
         assert result.sessions[1]["session_id"] == "session3"
         assert result.sessions[2]["session_id"] == "session1"
 
-    def test_first_page_returns_correct_sessions(self, temp_sessions_dir):
+    def test_first_page_metadata(self, temp_sessions_dir):
         create_sessions(temp_sessions_dir, 75)
-
-        repo = SessionRepository(temp_sessions_dir, page_size=50)
-        result = repo.list_paginated(page=1)
+        result = SessionRepository(temp_sessions_dir, page_size=50).list_paginated(
+            page=1
+        )
 
         assert len(result.sessions) == 50
         assert result.total_count == 75
-        assert result.total_pages == 2
-        assert result.page == 1
-        assert result.page_size == 50
         assert result.has_previous_page is False
         assert result.has_next_page is True
 
-    def test_second_page_returns_remaining_sessions(self, temp_sessions_dir):
+    def test_second_page_metadata(self, temp_sessions_dir):
         create_sessions(temp_sessions_dir, 75)
-
-        repo = SessionRepository(temp_sessions_dir, page_size=50)
-        result = repo.list_paginated(page=2)
+        result = SessionRepository(temp_sessions_dir, page_size=50).list_paginated(
+            page=2
+        )
 
         assert len(result.sessions) == 25
-        assert result.total_count == 75
-        assert result.total_pages == 2
         assert result.page == 2
         assert result.has_previous_page is True
         assert result.has_next_page is False
 
     @pytest.mark.parametrize("invalid_page", [0, -1, -5])
     def test_invalid_page_clamped_to_one(self, single_session_dir, invalid_page):
-        repo = SessionRepository(single_session_dir)
-        result = repo.list_paginated(page=invalid_page)
+        result = SessionRepository(single_session_dir).list_paginated(page=invalid_page)
 
         assert result.page == 1
 
     def test_invalid_page_too_high_clamped_to_max(self, temp_sessions_dir):
         create_sessions(temp_sessions_dir, 10)
 
-        repo = SessionRepository(temp_sessions_dir, page_size=5)
-        result = repo.list_paginated(page=100)
+        result = SessionRepository(temp_sessions_dir, page_size=5).list_paginated(
+            page=100
+        )
 
         assert result.page == 2
         assert result.total_pages == 2
@@ -117,15 +108,13 @@ class TestSessionRepository:
     def test_total_pages_calculation(self, temp_sessions_dir):
         create_sessions(temp_sessions_dir, 101)
 
-        repo = SessionRepository(temp_sessions_dir, page_size=50)
-        result = repo.list_paginated()
+        result = SessionRepository(temp_sessions_dir, page_size=50).list_paginated()
 
         assert result.total_pages == 3
         assert result.total_count == 101
 
     def test_single_session_returns_one_page(self, single_session_dir):
-        repo = SessionRepository(single_session_dir)
-        result = repo.list_paginated()
+        result = SessionRepository(single_session_dir).list_paginated()
 
         assert result.total_pages == 1
         assert result.total_count == 1
@@ -133,9 +122,7 @@ class TestSessionRepository:
         assert result.has_next_page is False
 
     def test_to_dict_returns_all_fields(self, single_session_dir):
-        repo = SessionRepository(single_session_dir)
-        result = repo.list_paginated()
-        d = result.to_dict()
+        d = SessionRepository(single_session_dir).list_paginated().to_dict()
 
         assert "sessions" in d
         assert "total_count" in d

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -49,6 +49,93 @@ def create_session_with_logs(data_dir: Path, session_id: str, spans: list, logs:
                 f.write("\n")
 
 
+class TestListSessionsEndpoint:
+    def test_returns_empty_list_with_pagination_metadata_when_no_sessions(
+        self, client, temp_data_dir
+    ):
+        response = client.get("/api/sessions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sessions"] == []
+        assert data["total_count"] == 0
+        assert data["total_pages"] == 1
+        assert data["page"] == 1
+        assert data["page_size"] == 50
+        assert data["has_previous_page"] is False
+        assert data["has_next_page"] is False
+        assert "data_dir" in data
+
+    def test_returns_sessions_with_all_pagination_fields(self, client, temp_data_dir):
+        session_id = "testsession123"
+        spans = [
+            {
+                "name": "test-span",
+                "start_time_unix_nano": 1000000000000000000,
+                "end_time_unix_nano": 2000000000000000000,
+            }
+        ]
+        create_session_with_logs(temp_data_dir, session_id, spans, logs=[])
+
+        response = client.get("/api/sessions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["sessions"]) == 1
+        assert data["sessions"][0]["session_id"] == session_id
+        assert data["total_count"] == 1
+        assert data["total_pages"] == 1
+        assert data["page"] == 1
+        assert data["has_previous_page"] is False
+        assert data["has_next_page"] is False
+
+    def test_respects_page_query_parameter(self, client, temp_data_dir):
+        for i in range(60):
+            session_id = f"session{i:03d}"
+            spans = [
+                {
+                    "name": "test-span",
+                    "start_time_unix_nano": i * 1000000000000000000,
+                    "end_time_unix_nano": i * 1000000000000000000 + 1000000000,
+                }
+            ]
+            create_session_with_logs(temp_data_dir, session_id, spans, logs=[])
+
+        response = client.get("/api/sessions?page=2")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["sessions"]) == 10
+        assert data["total_count"] == 60
+        assert data["total_pages"] == 2
+        assert data["page"] == 2
+        assert data["has_previous_page"] is True
+        assert data["has_next_page"] is False
+
+    def test_invalid_page_defaults_to_valid_range(self, client, temp_data_dir):
+        session_id = "testsession123"
+        spans = [
+            {
+                "name": "test-span",
+                "start_time_unix_nano": 1000000000000000000,
+                "end_time_unix_nano": 2000000000000000000,
+            }
+        ]
+        create_session_with_logs(temp_data_dir, session_id, spans, logs=[])
+
+        response = client.get("/api/sessions?page=0")
+        assert response.status_code == 200
+        assert response.json()["page"] == 1
+
+        response = client.get("/api/sessions?page=-1")
+        assert response.status_code == 200
+        assert response.json()["page"] == 1
+
+        response = client.get("/api/sessions?page=999")
+        assert response.status_code == 200
+        assert response.json()["page"] == 1
+
+
 class TestGetLogsEndpoint:
     def test_returns_logs_for_valid_session(self, client, temp_data_dir):
         session_id = "abc123def456"

--- a/ui/js/sessions_list.js
+++ b/ui/js/sessions_list.js
@@ -24,6 +24,17 @@ function sessionsListApp() {
             await this.loadSessions();
         },
 
+        applySessionData(data) {
+            this.sessions = data.sessions || [];
+            this.dataDir = data.data_dir || '';
+            this.totalCount = data.total_count || 0;
+            this.totalPages = data.total_pages || 1;
+            this.pageSize = data.page_size || 50;
+            this.currentPage = data.page || 1;
+            this.hasPreviousPage = data.has_previous_page || false;
+            this.hasNextPage = data.has_next_page || false;
+        },
+
         async loadSessions() {
             if (this.loading) return;
 
@@ -32,24 +43,12 @@ function sessionsListApp() {
 
             try {
                 const response = await fetch(`/api/sessions?page=${this.currentPage}`);
-
                 if (token !== this.requestToken) return;
-
-                const data = await response.json();
-                this.sessions = data.sessions || [];
-                this.dataDir = data.data_dir || '';
-                this.totalCount = data.total_count || 0;
-                this.totalPages = data.total_pages || 1;
-                this.pageSize = data.page_size || 50;
-                this.currentPage = data.page || 1;
-                this.hasPreviousPage = data.has_previous_page || false;
-                this.hasNextPage = data.has_next_page || false;
+                this.applySessionData(await response.json());
             } catch (error) {
                 console.error('Failed to load sessions:', error);
             } finally {
-                if (token === this.requestToken) {
-                    this.loading = false;
-                }
+                if (token === this.requestToken) this.loading = false;
             }
         },
 

--- a/ui/js/sessions_list.js
+++ b/ui/js/sessions_list.js
@@ -25,14 +25,14 @@ function sessionsListApp() {
         },
 
         applySessionData(data) {
-            this.sessions = data.sessions || [];
-            this.dataDir = data.data_dir || '';
-            this.totalCount = data.total_count || 0;
-            this.totalPages = data.total_pages || 1;
-            this.pageSize = data.page_size || 50;
-            this.currentPage = data.page || 1;
-            this.hasPreviousPage = data.has_previous_page || false;
-            this.hasNextPage = data.has_next_page || false;
+            this.sessions = data.sessions;
+            this.dataDir = data.data_dir;
+            this.totalCount = data.total_count;
+            this.totalPages = data.total_pages;
+            this.pageSize = data.page_size;
+            this.currentPage = data.page;
+            this.hasPreviousPage = data.has_previous_page;
+            this.hasNextPage = data.has_next_page;
         },
 
         async loadSessions() {

--- a/ui/js/sessions_list.js
+++ b/ui/js/sessions_list.js
@@ -7,19 +7,82 @@ function sessionsListApp() {
         uploading: false,
         uploadError: null,
 
+        currentPage: 1,
+        totalCount: 0,
+        totalPages: 1,
+        pageSize: 50,
+        hasPreviousPage: false,
+        hasNextPage: false,
+        loading: false,
+
+        initialized: false,
+        requestToken: 0,
+
         async init() {
+            if (this.initialized) return;
+            this.initialized = true;
             await this.loadSessions();
         },
 
         async loadSessions() {
+            if (this.loading) return;
+
+            this.loading = true;
+            const token = ++this.requestToken;
+
             try {
-                const response = await fetch('/api/sessions');
+                const response = await fetch(`/api/sessions?page=${this.currentPage}`);
+
+                if (token !== this.requestToken) return;
+
                 const data = await response.json();
                 this.sessions = data.sessions || [];
                 this.dataDir = data.data_dir || '';
+                this.totalCount = data.total_count || 0;
+                this.totalPages = data.total_pages || 1;
+                this.pageSize = data.page_size || 50;
+                this.currentPage = data.page || 1;
+                this.hasPreviousPage = data.has_previous_page || false;
+                this.hasNextPage = data.has_next_page || false;
             } catch (error) {
                 console.error('Failed to load sessions:', error);
+            } finally {
+                if (token === this.requestToken) {
+                    this.loading = false;
+                }
             }
+        },
+
+        async goToPage(page) {
+            if (page < 1 || page > this.totalPages || page === this.currentPage) return;
+            this.currentPage = page;
+            await this.loadSessions();
+        },
+
+        async previousPage() {
+            if (this.hasPreviousPage) {
+                await this.goToPage(this.currentPage - 1);
+            }
+        },
+
+        async nextPage() {
+            if (this.hasNextPage) {
+                await this.goToPage(this.currentPage + 1);
+            }
+        },
+
+        get showingRangeText() {
+            if (this.loading) return 'Loading...';
+            if (this.totalCount === 0) return '0 sessions';
+
+            const start = (this.currentPage - 1) * this.pageSize + 1;
+            const end = Math.min(this.currentPage * this.pageSize, this.totalCount);
+
+            if (this.totalPages === 1) {
+                return `${this.totalCount} session${this.totalCount !== 1 ? 's' : ''}`;
+            }
+
+            return `Showing ${start}-${end} of ${this.totalCount} sessions`;
         },
 
         async uploadSession() {

--- a/ui/js/sessions_list.js
+++ b/ui/js/sessions_list.js
@@ -52,35 +52,36 @@ function sessionsListApp() {
             }
         },
 
+        isValidPageChange(page) {
+            return page >= 1 && page <= this.totalPages && page !== this.currentPage;
+        },
+
         async goToPage(page) {
-            if (page < 1 || page > this.totalPages || page === this.currentPage) return;
+            if (!this.isValidPageChange(page)) return;
             this.currentPage = page;
             await this.loadSessions();
         },
 
         async previousPage() {
-            if (this.hasPreviousPage) {
-                await this.goToPage(this.currentPage - 1);
-            }
+            await this.goToPage(this.currentPage - 1);
         },
 
         async nextPage() {
-            if (this.hasNextPage) {
-                await this.goToPage(this.currentPage + 1);
-            }
+            await this.goToPage(this.currentPage + 1);
+        },
+
+        formatSessionCount(count) {
+            const suffix = count !== 1 ? 's' : '';
+            return `${count} session${suffix}`;
         },
 
         get showingRangeText() {
             if (this.loading) return 'Loading...';
             if (this.totalCount === 0) return '0 sessions';
+            if (this.totalPages === 1) return this.formatSessionCount(this.totalCount);
 
             const start = (this.currentPage - 1) * this.pageSize + 1;
             const end = Math.min(this.currentPage * this.pageSize, this.totalCount);
-
-            if (this.totalPages === 1) {
-                return `${this.totalCount} session${this.totalCount !== 1 ? 's' : ''}`;
-            }
-
             return `Showing ${start}-${end} of ${this.totalCount} sessions`;
         },
 

--- a/ui/sessions_list.html
+++ b/ui/sessions_list.html
@@ -31,7 +31,7 @@
 
     <main class="flex-1 overflow-auto px-8 pb-16">
         <div class="flex items-center justify-between mt-6 mb-4">
-            <h1 class="text-white text-xl font-semibold" x-text="`${sessions.length} sessions`"></h1>
+            <h1 class="text-white text-xl font-semibold" x-text="showingRangeText"></h1>
             <button @click="showUploadSection = !showUploadSection"
                     class="flex items-center gap-2 bg-white/5 text-white/40 border border-white/10 hover:bg-white/10 hover:text-white/60 rounded px-3 py-1.5 text-xs font-mono transition-all duration-200 cursor-pointer"
                     :class="{ 'bg-amber-500/20 text-amber-400 border-amber-500/30': showUploadSection }">
@@ -105,6 +105,28 @@
                 </template>
             </tbody>
         </table>
+        </div>
+
+        <div x-show="totalPages > 1" class="flex items-center justify-center gap-4 mt-6">
+            <button @click="previousPage()"
+                    :disabled="!hasPreviousPage || loading"
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono rounded border transition-all duration-200"
+                    :class="hasPreviousPage && !loading ? 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10 hover:text-white cursor-pointer' : 'bg-white/[0.02] text-white/30 border-white/5 cursor-not-allowed'">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3.5 h-3.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+                </svg>
+                Prev
+            </button>
+            <span class="text-white/50 text-xs font-mono" x-text="`Page ${currentPage} of ${totalPages}`"></span>
+            <button @click="nextPage()"
+                    :disabled="!hasNextPage || loading"
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono rounded border transition-all duration-200"
+                    :class="hasNextPage && !loading ? 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10 hover:text-white cursor-pointer' : 'bg-white/[0.02] text-white/30 border-white/5 cursor-not-allowed'">
+                Next
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3.5 h-3.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                </svg>
+            </button>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary

- Add page-based pagination to the sessions list with a fixed page size of 50
- Create `SessionRepository` class to abstract pagination logic (per CLAUDE.md guidance)
- Fix duplicate requests on page refresh via `initialized` flag and request token handling
- Add Prev/Next pagination controls to the UI

Fixes #27

---

**API Response Format:**
```json
{
  "sessions": [...],
  "total_count": 127,
  "total_pages": 3,
  "page": 1,
  "page_size": 50,
  "has_previous_page": false,
  "has_next_page": true,
  "data_dir": "/path/to/sessions"
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)