### PR TITLE
Add text aggregation display and fix missing user-bot latency

### DIFF
--- a/examples/pipecat/webrtc/bot.py
+++ b/examples/pipecat/webrtc/bot.py
@@ -83,28 +83,7 @@ transport_params = {
 }
 
 
-async def run_bot(transport: BaseTransport):
-    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
-
-    tts = CartesiaTTSService(
-        api_key=os.getenv("CARTESIA_API_KEY"),
-        voice_id="f786b574-daa5-4673-aa0c-cbe3e8534c02",
-    )
-
-    llm = OpenAILLMService(
-        api_key=os.getenv("OPENAI_API_KEY"),
-        params=OpenAILLMService.InputParams(temperature=0.5),
-    )
-
-    llm.register_function("add_item_to_order", add_item_to_order)
-    llm.register_function("remove_item_from_order", remove_item_from_order)
-    llm.register_function("get_order_summary", get_order_summary)
-    llm.register_function("submit_order", submit_order)
-
-    @llm.event_handler("on_function_calls_started")
-    async def on_function_calls_started(service, function_calls):
-        await tts.queue_frame(TTSSpeakFrame("One sec."))
-
+def _build_tools_schema() -> ToolsSchema:
     add_item_schema = FunctionSchema(
         name="add_item_to_order",
         description="Add an item to the customer's order",
@@ -158,7 +137,7 @@ async def run_bot(transport: BaseTransport):
         required=["customer_name"],
     )
 
-    tools = ToolsSchema(
+    return ToolsSchema(
         standard_tools=[
             add_item_schema,
             remove_item_schema,
@@ -167,7 +146,9 @@ async def run_bot(transport: BaseTransport):
         ]
     )
 
-    messages = [
+
+def _build_system_messages() -> list[dict]:
+    return [
         {
             "role": "system",
             "content": """You are Sam, a friendly barista at a cozy neighborhood coffee shop. You're warm and welcoming but efficient - you keep conversations moving without being rushed.
@@ -189,6 +170,41 @@ Behavior:
 Your output will be converted to audio so don't include special characters. Be conversational and brief.""",
         },
     ]
+
+
+def _create_services():
+    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+
+    tts = CartesiaTTSService(
+        api_key=os.getenv("CARTESIA_API_KEY"),
+        voice_id="f786b574-daa5-4673-aa0c-cbe3e8534c02",
+    )
+
+    llm = OpenAILLMService(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        params=OpenAILLMService.InputParams(temperature=0.5),
+    )
+
+    return stt, tts, llm
+
+
+def _register_llm_tools(llm, tts):
+    llm.register_function("add_item_to_order", add_item_to_order)
+    llm.register_function("remove_item_from_order", remove_item_from_order)
+    llm.register_function("get_order_summary", get_order_summary)
+    llm.register_function("submit_order", submit_order)
+
+    @llm.event_handler("on_function_calls_started")
+    async def on_function_calls_started(service, function_calls):
+        await tts.queue_frame(TTSSpeakFrame("One sec."))
+
+
+async def run_bot(transport: BaseTransport):
+    stt, tts, llm = _create_services()
+    _register_llm_tools(llm, tts)
+
+    tools = _build_tools_schema()
+    messages = _build_system_messages()
 
     context = LLMContext(messages, tools)
     context_aggregator = LLMContextAggregatorPair(

--- a/examples/pipecat/webrtc/bot.py
+++ b/examples/pipecat/webrtc/bot.py
@@ -18,6 +18,7 @@ from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
@@ -190,7 +191,10 @@ Your output will be converted to audio so don't include special characters. Be c
     ]
 
     context = LLMContext(messages, tools)
-    context_aggregator = LLMContextAggregatorPair(context)
+    context_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
 
     pipeline = Pipeline(
         [

--- a/ui/js/span_formatting.js
+++ b/ui/js/span_formatting.js
@@ -141,6 +141,19 @@ function spanFormattingMixin() {
             return formatDuration(ttfbSeconds * 1000);
         },
 
+        getTextAggregation(span) {
+            if (!span || !span.attributes) return null;
+            const attr = span.attributes.find(a => a.key === 'turn.text_aggregation_seconds');
+            if (!attr || !attr.value.double_value) return null;
+            return attr.value.double_value;
+        },
+
+        formatTextAggregation(span) {
+            const seconds = this.getTextAggregation(span);
+            if (seconds === null) return '';
+            return formatDuration(seconds * 1000);
+        },
+
         getUserBotLatency(span) {
             if (!span || !span.attributes) return null;
             const latencyAttr = span.attributes.find(a => a.key === 'turn.user_bot_latency_seconds');

--- a/ui/session_detail.html
+++ b/ui/session_detail.html
@@ -492,6 +492,10 @@
                         <label class="text-white/40 font-semibold text-xs" title="Time to First Byte">TTFB</label>
                         <span class="text-white text-xs" x-text="formatTTFB(selectedSpan)"></span>
                     </div>
+                    <div class="grid grid-cols-[150px_1fr] gap-4" x-show="getTextAggregation(selectedSpan) !== null">
+                        <label class="text-white/40 font-semibold text-xs" title="Time from first LLM token to first complete sentence">Text Aggregation</label>
+                        <span class="text-white text-xs" x-text="formatTextAggregation(selectedSpan)"></span>
+                    </div>
                     <div class="grid grid-cols-[150px_1fr] gap-4" x-show="getUserBotLatency(selectedSpan) !== null">
                         <label class="text-white/40 font-semibold text-xs">User ↔ Bot Latency</label>
                         <span class="text-white text-xs" x-html="formatUserBotLatency(selectedSpan)"></span>


### PR DESCRIPTION
## Summary

- Display `turn.text_aggregation_seconds` on turn spans in the trace UI (new attribute from upcoming pipecat PR)
- Fix missing `turn.user_bot_latency_seconds` by passing `vad_analyzer` to `LLMContextAggregatorPair` in the example bot, matching pipecat's recommended pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)