### PR TITLE
Display user turn duration on turn spans in trace UI

### DIFF
--- a/ui/js/span_formatting.js
+++ b/ui/js/span_formatting.js
@@ -154,6 +154,19 @@ function spanFormattingMixin() {
             return formatDuration(seconds * 1000);
         },
 
+        getUserTurnSeconds(span) {
+            if (!span || !span.attributes) return null;
+            const attr = span.attributes.find(a => a.key === 'turn.user_turn_seconds');
+            if (!attr || !attr.value.double_value) return null;
+            return attr.value.double_value;
+        },
+
+        formatUserTurnSeconds(span) {
+            const seconds = this.getUserTurnSeconds(span);
+            if (seconds === null) return '';
+            return formatDuration(seconds * 1000);
+        },
+
         getUserBotLatency(span) {
             if (!span || !span.attributes) return null;
             const latencyAttr = span.attributes.find(a => a.key === 'turn.user_bot_latency_seconds');

--- a/ui/session_detail.html
+++ b/ui/session_detail.html
@@ -496,6 +496,10 @@
                         <label class="text-white/40 font-semibold text-xs" title="Time from first LLM token to first complete sentence">Text Aggregation</label>
                         <span class="text-white text-xs" x-text="formatTextAggregation(selectedSpan)"></span>
                     </div>
+                    <div class="grid grid-cols-[150px_1fr] gap-4" x-show="getUserTurnSeconds(selectedSpan) !== null">
+                        <label class="text-white/40 font-semibold text-xs" title="Duration from user silence to turn release (VAD, STT, turn analyzer)">User Turn</label>
+                        <span class="text-white text-xs" x-text="formatUserTurnSeconds(selectedSpan)"></span>
+                    </div>
                     <div class="grid grid-cols-[150px_1fr] gap-4" x-show="getUserBotLatency(selectedSpan) !== null">
                         <label class="text-white/40 font-semibold text-xs">User ↔ Bot Latency</label>
                         <span class="text-white text-xs" x-html="formatUserBotLatency(selectedSpan)"></span>


### PR DESCRIPTION
## Summary

- Add "User Turn" row to turn span detail panel, showing `turn.user_turn_seconds` (duration from user silence to turn release)
- Follows same pattern as text aggregation display from PR #35

Depends on upstream pipecat PR: `itsderek23/pipecat#add-latency-breakdown-to-otel-turn-span`

🤖 Generated with [Claude Code](https://claude.com/claude-code)