### PR TITLE
Add function_call span support to trace UI

### DIFF
--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -22,6 +22,7 @@
     --span-llm: #ec4899;
     --span-tts: #a855f7;
     --span-turn: #10b981;
+    --span-function_call: #06b6d4;
     --span-default: #6b7280;
 
     --waterfall-row-height: 32px;
@@ -74,6 +75,7 @@ button:focus-visible {
 .bar-tts { background: var(--span-tts); }
 .bar-turn { background: var(--span-turn); }
 .bar-conversation { background: #3f3f46; }
+.bar-function_call { background: var(--span-function_call); }
 
 .selected .timeline-bar,
 .timeline-bar.selected {

--- a/ui/session_detail.html
+++ b/ui/session_detail.html
@@ -14,6 +14,7 @@
                         'span-llm': '#ec4899',
                         'span-tts': '#a855f7',
                         'span-turn': '#10b981',
+                        'span-function_call': '#06b6d4',
                     }
                 }
             }
@@ -484,6 +485,10 @@
             </div>
             <div class="p-8">
                 <div class="grid gap-4 mb-8">
+                    <div class="grid grid-cols-[150px_1fr] gap-4" x-show="selectedSpan?.name === 'function_call' && hasAttribute(selectedSpan, 'tool.function_name')">
+                        <label class="text-white/40 font-semibold text-xs">Function</label>
+                        <span class="text-white text-xs font-mono" x-text="getAttribute(selectedSpan, 'tool.function_name')"></span>
+                    </div>
                     <div class="grid grid-cols-[150px_1fr] gap-4">
                         <label class="text-white/40 font-semibold text-xs">Duration:</label>
                         <span class="text-white text-xs" x-text="formatSpanDuration(selectedSpan)"></span>


### PR DESCRIPTION
## Summary
- Add cyan (#06b6d4) color for `function_call` span bars in the trace timeline so they render visibly
- Display the `tool.function_name` attribute at the top of the side panel when a function_call span is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)